### PR TITLE
Modernize Python 2 code to get ready for Python 3

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -100,6 +100,7 @@ sudo -H pip install intervaltree
 sudo -H pip install 'mock>=2.0.0'
 sudo -H pip install 'numpy==1.12'
 sudo -H pip install 'scipy==1.0'
+sudo -H pip install 'six>=1.11.0'
 
 # Install Java (required for Bazel)
 ################################################################################

--- a/nucleus/examples/add_ad_to_vcf.py
+++ b/nucleus/examples/add_ad_to_vcf.py
@@ -33,11 +33,7 @@ from nucleus.io import vcf
 from nucleus.util import variant_utils
 from nucleus.util import variantcall_utils
 from nucleus.util import vcf_constants
-
-try:
-    xrange          # Python 2
-except NameError:
-    xrange = range  # Python 3
+from six.moves import xrange
 
 
 def get_variant_ad(variant):

--- a/nucleus/examples/add_ad_to_vcf.py
+++ b/nucleus/examples/add_ad_to_vcf.py
@@ -34,6 +34,11 @@ from nucleus.util import variant_utils
 from nucleus.util import variantcall_utils
 from nucleus.util import vcf_constants
 
+try:
+    xrange          # Python 2
+except NameError:
+    xrange = range  # Python 3
+
 
 def get_variant_ad(variant):
   """Returns the allele depth for the Variant, calculated across its calls."""

--- a/nucleus/io/fasta_test.py
+++ b/nucleus/io/fasta_test.py
@@ -26,6 +26,8 @@ from nucleus.io import fasta
 from nucleus.testing import test_utils
 from nucleus.util import ranges
 
+from six import string_types
+
 
 class RefFastaReaderTests(parameterized.TestCase):
 
@@ -117,8 +119,8 @@ class InMemoryRefReaderTests(parameterized.TestCase):
       self.assertContigsAreEqual(self.in_mem.contig(contig.name), contig)
 
   def test_str_and_repr(self):
-    self.assertIsInstance(str(self.in_mem), basestring)
-    self.assertIsInstance(repr(self.in_mem), basestring)
+    self.assertIsInstance(str(self.in_mem), string_types)
+    self.assertIsInstance(repr(self.in_mem), string_types)
 
   def test_unknown_contig(self):
     for reader in [self.fasta_reader, self.in_mem]:

--- a/nucleus/io/sam_test.py
+++ b/nucleus/io/sam_test.py
@@ -31,6 +31,11 @@ from nucleus.util import io_utils
 from nucleus.util import ranges
 from tensorflow.python.platform import gfile
 
+try:
+    integer_types = (int, long)  # Python 2
+except NameError:
+    integer_types = (int, )      # Python 3
+
 
 class SamReaderTests(parameterized.TestCase):
   """Test the iteration functionality provided by io.SamReader."""
@@ -54,7 +59,7 @@ class SamReaderTests(parameterized.TestCase):
     with reader:
       iterable = reader.iterate()
       # We expect 106 records in total.
-      for _ in xrange(10):
+      for _ in range(10):
         results = list(itertools.islice(iterable, 10))
         self.assertEqual(len(results), 10)
       results = list(itertools.islice(iterable, 10))
@@ -179,7 +184,7 @@ class SamReaderTests(parameterized.TestCase):
                                               expected_values):
         if isinstance(expected_value, float):
           self.assertAlmostEqual(actual_value.number_value, expected_value)
-        elif isinstance(expected_value, (int, long)):
+        elif isinstance(expected_value, integer_types):
           self.assertEqual(actual_value.int_value, expected_value)
         elif isinstance(expected_value, str):
           self.assertEqual(actual_value.string_value, expected_value)

--- a/nucleus/io/sam_test.py
+++ b/nucleus/io/sam_test.py
@@ -29,12 +29,8 @@ from nucleus.protos import reference_pb2
 from nucleus.testing import test_utils
 from nucleus.util import io_utils
 from nucleus.util import ranges
+from six import integer_types
 from tensorflow.python.platform import gfile
-
-try:
-    integer_types = (int, long)  # Python 2
-except NameError:
-    integer_types = (int, )      # Python 3
 
 
 class SamReaderTests(parameterized.TestCase):

--- a/nucleus/testing/test_utils.py
+++ b/nucleus/testing/test_utils.py
@@ -20,7 +20,7 @@ from __future__ import print_function
 
 import os
 
-
+from six import integer_types
 from tensorflow import flags
 from absl.testing import absltest
 
@@ -30,11 +30,6 @@ from nucleus.protos import struct_pb2
 from nucleus.protos import variants_pb2
 from nucleus.util import cigar as _cigar
 from tensorflow.python.platform import gfile
-
-try:
-    integer_types = (int, long)  # Python 2
-except NameError:
-    integer_types = (int, )      # Python 3
 
 FLAGS = flags.FLAGS
 

--- a/nucleus/testing/test_utils.py
+++ b/nucleus/testing/test_utils.py
@@ -31,6 +31,11 @@ from nucleus.protos import variants_pb2
 from nucleus.util import cigar as _cigar
 from tensorflow.python.platform import gfile
 
+try:
+    integer_types = (int, long)  # Python 2
+except NameError:
+    integer_types = (int, )      # Python 3
+
 FLAGS = flags.FLAGS
 
 # In the OSS version these will be ''.
@@ -112,7 +117,7 @@ def set_list_values(list_value, values):
       return struct_pb2.Value(string_value=value)
     elif isinstance(value, float):
       return struct_pb2.Value(number_value=value)
-    elif isinstance(value, (int, long)):
+    elif isinstance(value, integer_types):
       return struct_pb2.Value(int_value=value)
     else:
       raise ValueError('Unsupported type ', value)

--- a/nucleus/util/cigar.py
+++ b/nucleus/util/cigar.py
@@ -21,11 +21,7 @@ from __future__ import print_function
 import re
 
 from nucleus.protos import cigar_pb2
-
-try:
-    basestring            # Python 2
-except NameError:
-    basestring = (str, )  # Python 3
+from six import string_types
 
 # A frozenset of all CigarUnit.Operation enum values at advance the alignment
 # w.r.t. the reference genome.
@@ -146,14 +142,14 @@ def to_cigar_unit(source):
   try:
     if isinstance(source, cigar_pb2.CigarUnit):
       return source
-    elif isinstance(source, basestring):
+    elif isinstance(source, string_types):
       l, op = source[:-1], source[-1]
     elif isinstance(source, (tuple, list)):
       l, op = source
     else:
       raise ValueError('Unexpected source', source)
 
-    if isinstance(op, basestring):
+    if isinstance(op, string_types):
       op = CHAR_TO_CIGAR_OPS[op]
     l = int(l)
     if l < 1:
@@ -178,7 +174,7 @@ def to_cigar_units(source):
   Returns:
     list[CigarUnit].
   """
-  if isinstance(source, basestring):
+  if isinstance(source, string_types):
     return parse_cigar_string(source)
   else:
     return [to_cigar_unit(singleton) for singleton in source]

--- a/nucleus/util/cigar.py
+++ b/nucleus/util/cigar.py
@@ -20,9 +20,12 @@ from __future__ import print_function
 
 import re
 
-
-
 from nucleus.protos import cigar_pb2
+
+try:
+    basestring            # Python 2
+except NameError:
+    basestring = (str, )  # Python 3
 
 # A frozenset of all CigarUnit.Operation enum values at advance the alignment
 # w.r.t. the reference genome.

--- a/nucleus/util/io_utils.py
+++ b/nucleus/util/io_utils.py
@@ -32,13 +32,9 @@ import re
 
 import contextlib2
 
+from six import string_types
 from tensorflow.core.example import example_pb2
 from tensorflow.python.lib.io import python_io
-
-try:
-    basestring            # Python 2
-except NameError:
-    basestring = (str, )  # Python 3
 
 SHARD_SPEC_PATTERN = re.compile(R'((.*)\@(\d*[1-9]\d*)(?:\.(.+))?)')
 
@@ -238,9 +234,9 @@ def maybe_generate_sharded_filenames(filespec):
     A list of file paths.
 
   Raises:
-    TypeError: if filespec is not valid basestring type.
+    TypeError: if filespec is not in valid string_types.
   """
-  if not isinstance(filespec, basestring):
+  if not isinstance(filespec, string_types):
     raise TypeError('Invalid filespec: %s' % filespec)
   if IsShardedFileSpec(filespec):
     return GenerateShardedFilenames(filespec)

--- a/nucleus/util/io_utils.py
+++ b/nucleus/util/io_utils.py
@@ -30,12 +30,15 @@ import math
 import os
 import re
 
-
-
 import contextlib2
 
 from tensorflow.core.example import example_pb2
 from tensorflow.python.lib.io import python_io
+
+try:
+    basestring            # Python 2
+except NameError:
+    basestring = (str, )  # Python 3
 
 SHARD_SPEC_PATTERN = re.compile(R'((.*)\@(\d*[1-9]\d*)(?:\.(.+))?)')
 

--- a/nucleus/util/struct_utils_test.py
+++ b/nucleus/util/struct_utils_test.py
@@ -24,6 +24,11 @@ from nucleus.util import struct_utils
 from nucleus.protos import struct_pb2
 from nucleus.protos import variants_pb2
 
+try:
+    long        # Python 2
+except NameError:
+    long = int  # Python 3
+
 
 def _set_protomap_from_dict(d):
   """Returns a proto Map(str --> ListValue) with the given fields set.
@@ -174,8 +179,8 @@ class StructUtilsTest(parameterized.TestCase):
       dict(value=[], is_single_field=False, expected=[]),
       dict(value=[], is_single_field=True, expected=[]),
       dict(value=[1], is_single_field=False, expected=[1]),
-      dict(value=[1L], is_single_field=True, expected=1),
-      dict(value=[1, 2L], is_single_field=False, expected=[1, 2]),
+      dict(value=[long(1)], is_single_field=True, expected=1),
+      dict(value=[1, long(2)], is_single_field=False, expected=[1, 2]),
       dict(value=[1, 2], is_single_field=True, expected=1),
   )
   def test_get_int_field(self, value, is_single_field, expected):

--- a/nucleus/util/variant_utils_test.py
+++ b/nucleus/util/variant_utils_test.py
@@ -24,6 +24,7 @@ import itertools
 from absl.testing import absltest
 from absl.testing import parameterized
 import mock
+from six.moves import xrange
 
 from nucleus.protos import struct_pb2
 from nucleus.protos import variants_pb2
@@ -31,11 +32,6 @@ from nucleus.testing import test_utils
 from nucleus.util import ranges
 from nucleus.util import struct_utils
 from nucleus.util import variant_utils
-
-try:
-    xrange          # Python 2
-except NameError:
-    xrange = range  # Python 3
 
 NO_MISMATCH = set()
 EVAL_DUP = variant_utils.AlleleMismatchType.duplicate_eval_alleles

--- a/nucleus/util/variant_utils_test.py
+++ b/nucleus/util/variant_utils_test.py
@@ -32,6 +32,11 @@ from nucleus.util import ranges
 from nucleus.util import struct_utils
 from nucleus.util import variant_utils
 
+try:
+    xrange          # Python 2
+except NameError:
+    xrange = range  # Python 3
+
 NO_MISMATCH = set()
 EVAL_DUP = variant_utils.AlleleMismatchType.duplicate_eval_alleles
 TRUE_DUP = variant_utils.AlleleMismatchType.duplicate_true_alleles


### PR DESCRIPTION
Changes to deal with the fact that __basestring__, __long__, and __xrange()__ were removed in Python 3.