### PR TITLE
Add GitHub Action to Test & Build Nucleus

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,4 +11,3 @@ jobs:
         set -x -e
         source install.sh
         bazel test -c opt $COPT_FLAGS nucleus/...
-        echo test, and deploy your project.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,14 @@
+name: Test
+
+on: [push, pull_request]
+jobs:
+  build:
+    runs-on: ubuntu-16.04
+    steps:
+    - uses: actions/checkout@v1
+    - name: Install & Test 
+      run: |
+        set -x -e
+        source install.sh
+        bazel test -c opt $COPT_FLAGS nucleus/...
+        echo test, and deploy your project.

--- a/install.sh
+++ b/install.sh
@@ -55,7 +55,7 @@ sudo -H apt-get -y install libssl-dev libcurl4-openssl-dev liblz-dev libbz2-dev 
 # Install pip
 ################################################################################
 note_build_stage "Update pip"
-sudo -H apt-get -y install python-dev python3-pip python-wheel
+sudo -H apt-get -y install python-dev python3-pip python-wheel python3-setuptools
 sudo -H apt-get -y update
 # TensorFlow 2.0 requires pip >= 19.0
 python3 -m pip install --user -U pip


### PR DESCRIPTION
This change adds a [GitHub Action](https://github.com/features/actions) to automatically build Nucleus and run the tests for every commit and pull request to Nucleus. This augments existing Google internal builds/tests that are already run for Nucleus, with the added benefit that the result and logs are visible to GitHub users and Nucleus contributors throughout their development workflow in a standard way. 

To the Nucleus maintainers: let me know if you all think this makes sense--it may not, since the internal builds are a lot faster so exposing those build results somehow (kokoro?) may be better, or there may be other considerations to take into account here! I got the simple action working so figured I would send a PR (and since GitHub actions are becoming common for CI these days)! 😄  

This action would automatically build & test nucleus for PRs and commits to any branch.

<img width="824" alt="Screen Shot 2020-01-26 at 10 40 38 PM" src="https://user-images.githubusercontent.com/6299853/73154670-ecc2a600-408c-11ea-9fdd-dff5f366f9fb.png">

<img width="1057" alt="Screen Shot 2020-01-26 at 10 32 05 PM" src="https://user-images.githubusercontent.com/6299853/73154275-b173a780-408b-11ea-8271-763bddb78ff9.png">

